### PR TITLE
Harden all tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ following steps.
 ```bash
 git clone git@github.com:NearNodeFlash/site-gitops
 cd site-gitops
-tools/new-env.sh -e us-east-1 -r https://github.com/NearNodeFlash/site-gitops
+tools/new-env.sh -e us-east-1 -r https://github.com/NearNodeFlash/site-gitops -C /path/to/new/us-east-1-systemconfig.yaml 
 git add environments
 git commit -m 'create us-east-1'
 git push
@@ -69,16 +69,6 @@ cd site-gitops
 tar xfo $TARFILE -C environments/us-east-1
 git add environments/us-east-1
 git commit -m "Apply manifests for release $TAG"
-git push
-```
-
-Add the **SystemConfiguration** resource that describes the hardware in your new
-environment:
-
-```bash
-cp /path/to/new/us-east-1-systemconfig.yaml environments/us-east-1/nnf-sos/systemconfiguration.yaml
-git add environments/us-east-1
-git commit -m 'Add SystemConfiguration for us-east-1'
 git push
 ```
 

--- a/tools/apply-manifest.sh
+++ b/tools/apply-manifest.sh
@@ -53,8 +53,11 @@ elif [[ ! -r $MANIFEST ]]; then
 fi
 
 DBG=
-[[ -n $DRYRUN ]] && DBG=echo
+[[ -n $DRYRUN ]] && DBG="echo"
 
-$DBG tar xfo $MANIFEST -C environments/"$ENV"
+set -e
+set -o pipefail
+
+$DBG tar xfo "$MANIFEST" -C environments/"$ENV"
 exit $?
 

--- a/tools/deploy-env.sh
+++ b/tools/deploy-env.sh
@@ -54,13 +54,17 @@ fi
 
 LC_ALL=C
 DBG=
-[[ -n $DRYRUN ]] && DBG=echo
+[[ -n $DRYRUN ]] && DBG="echo"
+
+set -e
+set -o pipefail
+
 for x in environments/"$ENV"/*bootstrap*
 do
     if [[ -n $TO_LEVEL ]]; then
-        bn=$(basename $x)
+        bn=$(basename "$x")
         lvl=${bn%%-*}
-        if (( $lvl > $TO_LEVEL )); then
+        if (( lvl > TO_LEVEL )); then
             break
         fi
     fi

--- a/tools/undeploy-env.sh
+++ b/tools/undeploy-env.sh
@@ -19,18 +19,24 @@
 
 TO_LEVEL=1
 
-while getopts 'ne:l:h' opt; do
+while getopts 'ne:l:h:C' opt; do
 case "$opt" in
+C) DESTROY_CRDS=1 ;;
 e) ENV="$OPTARG" ;;
 l) TO_LEVEL="$OPTARG" ;;
 n) DRYRUN=1 ;;
 \?|h)
-    echo "Usage: $0 [-n] [-l LEVEL] -e ENVIRONMENT"
+    echo "Usage: $0 [-n] [-C] [-l LEVEL] -e ENVIRONMENT"
     echo
     echo "  -e ENVIRONMENT   Name of environment to undeploy."
     echo "  -l LEVEL         Undeploy bootstraps down to LEVEL, where LEVEL is"
     echo "                   a number >= 0. The default is to stop at level 1,"
     echo "                   to leave the level 0 bootstraps in place."
+    echo "  -C               Undeploy whole manifests rather than bootstraps."
+    echo "                   This removes Custom Resource Definitions (CRDs)."
+    echo "                   Use this after the bootstraps have been undeployed"
+    echo "                   and prior to an upgrade that modifies CRDs. This"
+    echo "                   honors the [-l LEVEL] arg."
     echo "  -n               Dry run."
     exit 1
     ;;
@@ -56,14 +62,95 @@ fi
 
 LC_ALL=C
 DBG=
-[[ -n $DRYRUN ]] && DBG=echo
-for x in $(echo environments/"$ENV"/*bootstrap* | awk '{ for (i=NF; i>0; i--) printf("%s ",$i); printf("\n")}')
-do
-    bn=$(basename $x)
-    lvl=${bn%%-*}
-    if (( $lvl < $TO_LEVEL )); then
-        break
+[[ -n $DRYRUN ]] && DBG="echo"
+
+set -e
+set -o pipefail
+
+# Deleting the bootstrap resources, the ArgoCD Application resources, is the
+# normal way to undeploy a service. ArgoCD will then delete anything that was
+# in the manifest for that service, but it will leave CRDs behind.
+delete_bootstraps() {
+    for x in $(echo environments/"$ENV"/*bootstrap* | awk '{ for (i=NF; i>0; i--) printf("%s ",$i); printf("\n")}')
+    do
+        bn=$(basename "$x")
+        lvl=${bn%%-*}
+        if (( lvl < TO_LEVEL )); then
+            break
+        fi
+        $DBG kubectl delete --ignore-not-found=true -k "$x"
+    done
+}
+
+_delete_manifest() {
+    local APP_YAML="$1"
+
+    # Stop if this Application is still active.
+    app_name=$(yq -M .metadata.name "$APP_YAML")
+    if kubectl get application -n argocd "$app_name" 1>/dev/null 2>&1 ; then
+        echo "Stopping at active Application resource $app_name."
+        exit 1
     fi
-    $DBG kubectl delete -k "$x"
-done
+
+    # Find the path to the service this Application resource controls.
+    svc_path=$(yq -M .spec.source.path "$APP_YAML")
+    if [[ ! -d $svc_path ]]; then
+        echo "Application $app_yaml refers to source path $svc_path which cannot be found in this workarea."
+        exit 1
+    fi
+
+    # Delete this service's manifest. The manifest includes the CRDs.
+    KBUILD="bin/kustomize build"
+    KDEL="kubectl delete --ignore-not-found=true -f-"
+    if [[ -n $DRYRUN ]]; then
+        echo "$KBUILD $svc_path | $KDEL"
+    else
+        $KBUILD "$svc_path" | $KDEL
+    fi
+}
+
+# Delete the manifests. ArgoCD does not remove CRDs and in most cases one would # not want to have them removed. If the CRD is removed then any resources
+# of that type would be deleted, and that would be considered data loss.
+# But sometimes we need to torch everything when the CRD version (e.g. v1alpha1)
+# has a change.
+#
+# This removes whole manifests, including the CRDs, in reverse order. It begins
+# with the highest-numbered Application resource in the highest-numbered
+# bootstrap directory and works down to the lowest-numbered Application
+# resource in the lowest-numbered bootstrap directory. It stops when it gets
+# to an Application resource that is still active, so it is safe to run this
+# repeatedly.
+delete_manifests() {
+    if [[ ! -x bin/kustomize ]]; then
+        if ! make kustomize; then
+            echo "Unable to retrieve the kustomize tool."
+            exit 1
+        fi
+    fi
+
+    # For each bootstrap level in reverse order...
+    for bootstrap_dir in $(echo environments/"$ENV"/*bootstrap* | awk '{ for (i=NF; i>0; i--) printf("%s ",$i); printf("\n")}')
+    do
+        bn=$(basename "$bootstrap_dir")
+        lvl=${bn%%-*}
+        if (( lvl < TO_LEVEL )); then
+            break
+        fi
+
+        # Within this bootstrap dir get each Application resource in
+        # reverse order...
+        for app_yaml in $(echo "$bootstrap_dir"/[0-9]*.yaml | awk '{ for (i=NF; i>0; i--) printf("%s ",$i); printf("\n")}')
+        do
+            [[ $(yq -M .kind "$app_yaml") == Application ]] || continue
+
+            _delete_manifest "$app_yaml"
+        done
+    done
+}
+
+if [[ -n $DESTROY_CRDS ]]; then
+    delete_manifests
+else
+    delete_bootstraps
+fi
 


### PR DESCRIPTION
Add a -C option to new-env.sh to allow the SystemConfiguration to be specified when a new environment is created.

Add a -C option to undeploy-env.sh to have it undeploy whole manifests. Normally the tool would undeploy the bootstrap resources, and ArgoCD would then remove the service described by each bootstrap.  However, ArgoCD does not remove CRDs that may have been included in the service.  By re-running the undeploy with -C, after the bootstraps have been undeployed, you can remove all traces of the service, including its CRDs.