### PR TITLE
A more fine-grained approach to server-side-apply

### DIFF
--- a/environments/example-env/2-bootstrap0/2-nnf-sos.yaml
+++ b/environments/example-env/2-bootstrap0/2-nnf-sos.yaml
@@ -29,11 +29,6 @@ spec:
       - CreateNamespace=true
       - PrunePropagationPolicy=foreground
       - PruneLast=true
-
-      # Nnf-sos has a large manifest due to the size of the
-      # nnfcontainerprofile CRD and the SystemConfiguration resource.
-      - ServerSideApply=true
-
   ignoreDifferences:
   - group: nnf.cray.hpe.com
     kind: NnfPortManager

--- a/environments/example-env/nnf-sos/kustomization.yaml
+++ b/environments/example-env/nnf-sos/kustomization.yaml
@@ -14,6 +14,37 @@ resources:
 - default-nnfstorageprofile.yaml
 - default-nnfdatamovementprofile.yaml
 
+patches:
+- target:
+    kind: CustomResourceDefinition
+    name: nnfdatamovementmanagers.nnf.cray.hpe.com
+  patch: |-
+    kind: CustomResourceDefinition
+    metadata:
+      name: nnfdatamovementmanagers.nnf.cray.hpe.com
+      annotations:
+        argocd.argoproj.io/sync-options: ServerSideApply=true
+- target:
+    kind: CustomResourceDefinition
+    name: nnfcontainerprofiles.nnf.cray.hpe.com
+  patch: |-
+    kind: CustomResourceDefinition
+    metadata:
+      name: nnfcontainerprofiles.nnf.cray.hpe.com
+      annotations:
+        argocd.argoproj.io/sync-options: ServerSideApply=true
+- target:
+    kind: SystemConfiguration
+    name: default
+    namespace: default
+  patch: |-
+    kind: SystemConfiguration
+    metadata:
+      name: default
+      annotations:
+        # Because on some systems this resource can be quite large.
+        argocd.argoproj.io/sync-options: ServerSideApply=true
+
 components:
 - ../components/container-locations
 - ../../universal/container-locations


### PR DESCRIPTION
The nnf-sos manifest is quite large because it has two CRDs that include corev1/PodSpec or PodTemplateSpec, and because on some systems the SystemConfiguration resource can be extensive. Rather than doing server-side apply for the whole manifest, just do it for the resources that require it.

This seems to greatly simplify the verification steps that argocd has to do for rolling-upgrade.