### PR TITLE
Define the specification of System Storage resources

### DIFF
--- a/environments/example-env/3-bootstrap0/1-site-config.yaml
+++ b/environments/example-env/3-bootstrap0/1-site-config.yaml
@@ -5,7 +5,7 @@ metadata:
   name: 1-site-config
   namespace: argocd
   finalizers:
-    - resources-finalizer.argocd.argoproj.io
+    - resources-finalizer.argocd.argoproj.io/background
 spec:
   project: rabbit
   source:

--- a/environments/example-env/nnf-sos/kustomization.yaml
+++ b/environments/example-env/nnf-sos/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
 - systemconfiguration.yaml
 - default-nnfstorageprofile.yaml
 - default-nnfdatamovementprofile.yaml
+- lvmlockd-profiles.yaml
 
 components:
 - ../components/container-locations

--- a/environments/example-env/nnf-sos/lvmlockd-profiles.yaml
+++ b/environments/example-env/nnf-sos/lvmlockd-profiles.yaml
@@ -1,0 +1,5 @@
+# This file contains the NnfStorageProfile resources that are used by
+# NnfSystemStorages.  The NnfSystemStorage resources are placed in:
+#   environments/$ENV/site-config/lvmlock-systemstorage.yaml
+# See: https://nearnodeflash.github.io/latest/guides/system-storage/readme/
+

--- a/environments/example-env/site-config/kustomization.yaml
+++ b/environments/example-env/site-config/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 
 resources:
 - mgt-pool-member-nnfstorageprofile.yaml
+- lvmlock-systemstorage.yaml

--- a/environments/example-env/site-config/lvmlock-systemstorage.yaml
+++ b/environments/example-env/site-config/lvmlock-systemstorage.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: systemstorage
+  annotations:
+    argocd.argoproj.io/sync-options: Delete=false
+---
+# Place your NnfSystemStorage resources here.
+# The matching NnfStorageProfiles should be placed in:
+#   environments/$ENV/nnf-sos/lvmlockd-profiles.yaml
+# See: https://nearnodeflash.github.io/latest/guides/system-storage/readme/
+


### PR DESCRIPTION
System Storage resources require NnfSystemStorage resources with matching NnfStorageProfile resources. To allow proper deletion behavior, and rolling-upgrade behavior, the two types of resources must be separated.

Place the NnfStorageProfiles in the nnf-sos manifest, where their CRD is found. Place the NnfSystemStorage resources in site-config. Mark the site-config Application to do background deletion.