### PR TITLE
Only a new profile with the name "default" should be default.

### DIFF
--- a/tools/unpack-manifest.py
+++ b/tools/unpack-manifest.py
@@ -164,8 +164,9 @@ def find_and_extract_template_resources(args, env_dir, component, messages):
     def create_default_resource(doc, name_of_default, default_prof_base, default_prof):
         # Given a template, create its default.
         with open(default_prof, "w", encoding="utf-8") as fd:
-            if "data" in doc and "default" in doc["data"]:
-                doc["data"]["default"] = True
+            if doc["metadata"]["name"] == "default":
+                if "data" in doc and "default" in doc["data"]:
+                    doc["data"]["default"] = True
             ns = doc["metadata"]["namespace"]
             del doc["metadata"]
             doc["metadata"] = {"name": name_of_default, "namespace": ns}


### PR DESCRIPTION
Only profiles that are named "default" should have data.default set to true. Other profiles of the same kind may have "default" somewhere in their name, but those profiles should NOT have data.default set to true.