### PR TITLE
Fix nnf-dm coredump patches

### DIFF
--- a/environments/example-env/nnf-dm/dm-controller-coredumps.yaml
+++ b/environments/example-env/nnf-dm/dm-controller-coredumps.yaml
@@ -1,14 +1,18 @@
-# Add Volume (does not currently have Volumes)
-- op: add
-  path: /spec/template/spec/volumes
-  value:
-    - name: core-dumps
-      hostPath:
-        path: /localdisk/dumps
-        type: DirectoryOrCreate
-# Add VolumeMount to manager container (does not currently have VolumeMounts)
-- op: add
-  path: /spec/template/spec/containers/1/volumeMounts
-  value:
-    - mountPath: /localdisk/dumps
-      name: core-dumps
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nnf-dm-manager-controller-manager
+  namespace: nnf-dm-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          volumeMounts:
+            - mountPath: /localdisk/dumps
+              name: core-dumps
+      volumes:
+        - name: core-dumps
+          hostPath:
+            path: /localdisk/dumps
+            type: DirectoryOrCreate

--- a/environments/example-env/nnf-dm/dm-manager-coredumps.yaml
+++ b/environments/example-env/nnf-dm/dm-manager-coredumps.yaml
@@ -1,4 +1,7 @@
-# Add Volume
+# Being a CRD, we cannot use a regular patch to add volumes - it will wipe out the entire container
+# spec. We must use JSON patches to patch a CRD.
+
+# Add Volume to existing volumes (a hyphen must be used)
 - op: add
   path: /spec/template/spec/volumes/-
   value:
@@ -7,16 +10,15 @@
       path: /localdisk/dumps
       type: DirectoryOrCreate
 
-# Add VolumeMount to existing worker container's VolumeMounts
+# Add VolumeMount to existing worker container's VolumeMounts (hyphen)
 - op: add
   path: /spec/template/spec/containers/0/volumeMounts/-
   value:
     mountPath: /localdisk/dumps
     name: core-dumps
-
-# Add VolumeMount to manager container (does not currently have VolumeMounts)
+# Add VolumeMount to existing manager container's VolumeMounts (hyphen)
 - op: add
-  path: /spec/template/spec/containers/1/volumeMounts
+  path: /spec/template/spec/containers/1/volumeMounts/-
   value:
-    - mountPath: /localdisk/dumps
-      name: core-dumps
+    mountPath: /localdisk/dumps
+    name: core-dumps

--- a/environments/example-env/nnf-dm/kustomization.yaml
+++ b/environments/example-env/nnf-dm/kustomization.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
@@ -12,15 +11,22 @@ components:
 - ../../universal/container-locations
 
 patches:
-- target:
+- path: dm-controller-coredumps.yaml
+  target:
+    kind: Deployment
+    name: nnf-dm-manager-controller-manager
+    namespace: nnf-dm-system
+- path: dm-manager-coredumps.yaml
+  target:
     group: nnf.cray.hpe.com
     kind: NnfDataMovementManager
     name: nnf-dm-manager-controller-manager
     namespace: nnf-dm-system
-  path: dm-manager-coredumps.yaml
-- target:
-    kind: Deployment
-    name: nnf-dm-manager-controller-manager
-    namespace: nnf-dm-system
-  path: dm-controller-coredumps.yaml
 
+
+  # Use images with mpifileutils/mpirun debug symbols
+images:
+- name: ghcr.io/nearnodeflash/nnf-dm
+  newName: ghcr.io/nearnodeflash/nnf-dm-debug
+- name: ghcr.io/nearnodeflash/nnf-mfu
+  newName: ghcr.io/nearnodeflash/nnf-mfu-debug


### PR DESCRIPTION
Problem: The json patch for the nnf-dm controller deployment is using indexes to patch the volumes, which is error prone. We recently had the containers switch indices, so the patch was being applied to the wrong container.

This changes the json patch to a strategic merge style patch for the deployment, allowing the container name to be used to apply the patch.

Unfortunately, we cannot use a strategic merge for the patch to the NnfDataMovementManager, since it is a CRD. Continue to use a JSON patch in this case. It is less risky than the deployment since there are two containers and we want to patch them both.