### PR TITLE
Make DWS upgrades go more smoothly

### DIFF
--- a/environments/example-env/dws/kustomization.yaml
+++ b/environments/example-env/dws/kustomization.yaml
@@ -9,3 +9,16 @@ resources:
 
 components:
 - ../../universal/container-locations
+
+patches:
+- target:
+    kind: Deployment
+    name: dws-webhook
+    namespace: dws-system
+  patch: |-
+    kind: Deployment
+    metadata:
+      name: dws-webhook
+      annotations:
+        argocd.argoproj.io/sync-options: Replace=true,PruneLast=false,Force=true
+

--- a/environments/example-env/nnf-sos/kustomization.yaml
+++ b/environments/example-env/nnf-sos/kustomization.yaml
@@ -10,7 +10,6 @@ resources:
 #- nnf-sos-prometheus.yaml
 
 # The following are cluster-specific and are not touched by unpack-manifest.
-- systemconfiguration.yaml
 - default-nnfstorageprofile.yaml
 - default-nnfdatamovementprofile.yaml
 - lvmlockd-profiles.yaml
@@ -33,17 +32,6 @@ patches:
     metadata:
       name: nnfcontainerprofiles.nnf.cray.hpe.com
       annotations:
-        argocd.argoproj.io/sync-options: ServerSideApply=true
-- target:
-    kind: SystemConfiguration
-    name: default
-    namespace: default
-  patch: |-
-    kind: SystemConfiguration
-    metadata:
-      name: default
-      annotations:
-        # Because on some systems this resource can be quite large.
         argocd.argoproj.io/sync-options: ServerSideApply=true
 
 components:

--- a/environments/example-env/site-config/kustomization.yaml
+++ b/environments/example-env/site-config/kustomization.yaml
@@ -3,5 +3,21 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+- systemconfiguration.yaml
 - mgt-pool-member-nnfstorageprofile.yaml
 - lvmlock-systemstorage.yaml
+
+patches:
+- target:
+    kind: SystemConfiguration
+    name: default
+    namespace: default
+  patch: |-
+    kind: SystemConfiguration
+    metadata:
+      name: default
+      annotations:
+        # ServerSideApply because on some systems this resource can be quite large.
+        # Replace to let this resource avoid the conversion webhook.
+        argocd.argoproj.io/sync-options: ServerSideApply=true,Replace=true
+


### PR DESCRIPTION
Note, for best behavior of DWS upgrades, these changes must be applied and active in the gitops repo prior to doing the DWS upgrade.

Apply the SystemConfiguration with ServerSideApply=true and Replace=true. On some systems this can be quite a large file, so it should be server-side. And for DWS API upgrades we have to make it easy to get this past the DWS conversion webhook so we deploy it with the equivalent of "kubectl replace".

Deploy the DWS webhook Deployment with Replace=true and Force=true. This allows the previous replicaset to cleanup the previous DWS webhook pods prior to starting the next replicaset. This addresses the issue where the previous pods never go away on their own, which prevented the new pods from progressing past Pending state.

Move the location of SystemConfiguration from the nnf-sos dir to the site-config dir. In previous testing we've found that this behaves better when deployed in this later stage. This is already active in the downstream gitops repos, and was missed when syncing with the boilerplate.