### PR TITLE
OpenSSL v1.1.1k compatibility

### DIFF
--- a/tools/mk-usercontainer-secrets.sh
+++ b/tools/mk-usercontainer-secrets.sh
@@ -154,7 +154,7 @@ DNS.1 = $SRVR_HOST
     echo "Generate a self-signed server certificate signing request and certificate"
     mkdir -p "$SERVER_DIR" && chmod 700 "$SERVER_DIR"
     openssl req -new -key "$CA_KEY" -out "$SERVER_CSR" -subj "/CN=$SRVR_HOST" -config "$RABBIT_SAN_CONF" -extensions 'v3_req'
-    openssl x509 -req -days 365 -in "$SERVER_CSR" -key "$CA_KEY" -out "$SERVER_CERT" -extfile "$RABBIT_SAN_CONF" -extensions 'v3_req'
+    openssl x509 -req -days 365 -in "$SERVER_CSR" -signkey "$CA_KEY" -out "$SERVER_CERT" -extfile "$RABBIT_SAN_CONF" -extensions 'v3_req'
 }
 
 # Create the secrets for the certificate and its signing key.


### PR DESCRIPTION
As of OpenSSL v3.0 the -signkey argument was renamed -key.  For compatibility -signkey is available as an alias in v3.0+.  Switch to using -signkey for compatibility with OpenSLL v1.1.1k, this is the officially supported version in RHEL 8.x.

OpenSSL documentation: https://docs.openssl.org/3.0/man1/openssl-x509/#input-output-and-general-purpose-options

```
-signkey filename|uri

This option is an alias of -key.
```

A matching change should be made to nnf-dm after this PR is finalized and merged. 