### PR TITLE
Fix verify-deployment references

### DIFF
--- a/tools/resync-env.sh
+++ b/tools/resync-env.sh
@@ -151,7 +151,7 @@ do
             bname=$(basename "$application")
             if ! grep -q "$bname" "$example_bootstrap/kustomization.yaml"; then
                 echo "  Error in $example_bootstrap: Resource $bname is not listed in kustomization.yaml"
-                echo "  Run: tools/verify-deployment.sh -e example-env"
+                echo "  Run: tools/verify-deployment.py -e example-env"
                 exit 1
             fi
             dest="environments/$ENV/$bstrapbase/$bname"

--- a/tools/unpack-manifest.py
+++ b/tools/unpack-manifest.py
@@ -81,7 +81,7 @@ def main():
     check_for_crd_updates(args, env_dir, upgrade_type, messages)
 
     # Last message: Remind the user to run the verification tool.
-    messages.append("Run 'tools/verify-deployment.sh'.")
+    messages.append("Run 'tools/verify-deployment.py'.")
     present_messages(args, env_dir, messages)
 
 


### PR DESCRIPTION
The references still mention a `.sh` script instead of `.py`. Fix it.